### PR TITLE
Remove Behaviors SDK reference, readd as nuget package.

### DIFF
--- a/AdventureWorks.Shopper/AdventureWorks.Shopper/AdventureWorks.Shopper.csproj
+++ b/AdventureWorks.Shopper/AdventureWorks.Shopper/AdventureWorks.Shopper.csproj
@@ -346,11 +346,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="BehaviorsXamlSDKManaged, Version=12.0">
-      <Name>Behaviors SDK %28XAML%29</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\AdventureWorks.UILogic\AdventureWorks.UILogic.csproj">
       <Project>{30061dc3-9d88-44a0-bdbe-01ce1f51d53d}</Project>
       <Name>AdventureWorks.UILogic</Name>

--- a/AdventureWorks.Shopper/AdventureWorks.Shopper/project.json
+++ b/AdventureWorks.Shopper/AdventureWorks.Shopper/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "Microsoft.Xaml.Behaviors.Uwp.Managed": "2.0.0",
     "Prism.Unity": "6.1.1",
     "StyleCop.MSBuild": "4.7.49.1"
   },


### PR DESCRIPTION
Made this change to make AdventureWorks.Shopper compile in VS2017. The reference to BehaviorsSDK was not found - I guess it was included in VS2015 but not in VS2017?
Hopefully this does not break it in VS2015 - I don't have it installed to test.