### PR TITLE
Make this build in VS15.2. Remove remaining references to DelegateCommandHack.

### DIFF
--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/BillingAddressPageViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/BillingAddressPageViewModel.cs
@@ -11,8 +11,7 @@ using System.Globalization;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
-namespace AdventureWorks.UILogic.ViewModels
-{
+namespace AdventureWorks.UILogic.ViewModels {
     public class BillingAddressPageViewModel : ViewModelBase
     {
         private readonly IBillingAddressUserControlViewModel _billingAddressViewModel;
@@ -30,7 +29,7 @@ namespace AdventureWorks.UILogic.ViewModels
             _accountService = accountService;
             _navigationService = navigationService;
 
-            SaveCommand = new DelegateCommand(async () => SaveAsync);
+            SaveCommand = new DelegateCommand(async () => await SaveAsync());
         }
 
         public IBillingAddressUserControlViewModel BillingAddressViewModel

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ChangeDefaultsFlyoutViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ChangeDefaultsFlyoutViewModel.cs
@@ -32,7 +32,7 @@ namespace AdventureWorks.UILogic.ViewModels
             _alertMessageService = alertMessageService;
             _accountService = accountService;
 
-            SaveCommand = new DelegateCommand(async () => SaveAsync);
+            SaveCommand = new DelegateCommand(async () => await SaveAsync());
 
             Initialize();
         }

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/CheckoutSummaryPageViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/CheckoutSummaryPageViewModel.cs
@@ -65,7 +65,7 @@ namespace AdventureWorks.UILogic.ViewModels
             _alertMessageService = alertMessageService;
             _signInUserControlViewModel = signInUserControlViewModel;
 
-            SubmitCommand =  new DelegateCommand(async () => SubmitAsync, CanSubmit);
+            SubmitCommand =  new DelegateCommand(async () => await SubmitAsync(), CanSubmit);
 
             EditCheckoutDataCommand = new DelegateCommand(EditCheckoutData);
             SelectCheckoutDataCommand = new DelegateCommand(async () => await SelectCheckoutDataAsync());

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ItemDetailPageViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ItemDetailPageViewModel.cs
@@ -39,8 +39,8 @@ namespace AdventureWorks.UILogic.ViewModels
             _resourceLoader = resourceLoader;
             _secondaryTileService = secondaryTileService;
 
-            PinProductCommand = new DelegateCommand(async () => PinProduct, () => SelectedProduct != null);
-            UnpinProductCommand = new DelegateCommand(async () => UnpinProduct, () => SelectedProduct != null);
+            PinProductCommand = new DelegateCommand(async () => await PinProduct(), () => SelectedProduct != null);
+            UnpinProductCommand = new DelegateCommand(async () => await UnpinProduct(), () => SelectedProduct != null);
         }
 
         public DelegateCommand PinProductCommand { get; private set; }

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/PaymentMethodPageViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/PaymentMethodPageViewModel.cs
@@ -38,7 +38,7 @@ namespace AdventureWorks.UILogic.ViewModels
             _accountService = accountService;
             _navigationService = navigationService;
 
-            SaveCommand = new DelegateCommand(async () => SaveAsync);
+            SaveCommand = new DelegateCommand(async () => await SaveAsync());
         }
 
         public IPaymentMethodUserControlViewModel PaymentMethodViewModel

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ProductViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ProductViewModel.cs
@@ -33,7 +33,7 @@ namespace AdventureWorks.UILogic.ViewModels
             _alertMessageService = alertMessageService;
             _resourceLoader = resourceLoader;
 
-            AddToCartCommand = new DelegateCommand(async () => AddToCart);
+            AddToCartCommand = new DelegateCommand(async () => await AddToCart());
         }
 
         public string Title

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ShippingAddressPageViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ShippingAddressPageViewModel.cs
@@ -30,7 +30,7 @@ namespace AdventureWorks.UILogic.ViewModels
             _accountService = accountService;
             _navigationService = navigationService;
 
-            SaveCommand = new DelegateCommand(async () => SaveAsync);
+            SaveCommand = new DelegateCommand(async () => await SaveAsync());
         }
 
         public IShippingAddressUserControlViewModel ShippingAddressViewModel

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ShoppingCartPageViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/ShoppingCartPageViewModel.cs
@@ -50,10 +50,10 @@ namespace AdventureWorks.UILogic.ViewModels
             _checkoutDataRepository = checkoutDataRepository;
             _orderRepository = orderRepository;
 
-            CheckoutCommand = new DelegateCommand(async () => CheckoutAsync, CanCheckout);
-            RemoveCommand = DelegateCommandHack<ShoppingCartItemViewModel>.FromAsyncHandler(Remove);
-            IncrementCountCommand = DelegateCommandHack.FromAsyncHandler(IncrementCount);
-            DecrementCountCommand = DelegateCommandHack.FromAsyncHandler(DecrementCount, CanDecrementCount);
+            CheckoutCommand = new DelegateCommand(async () => await CheckoutAsync(), CanCheckout);
+            RemoveCommand = new DelegateCommand<ShoppingCartItemViewModel>(async vm => await Remove(vm));
+            IncrementCountCommand = new DelegateCommand(async () => await IncrementCount());
+            DecrementCountCommand = new DelegateCommand(async () => await DecrementCount(), CanDecrementCount);
 
             // Subscribe to the ShoppingCartUpdated event
             if (eventAggregator != null)

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/SignInFlyoutViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/SignInFlyoutViewModel.cs
@@ -33,7 +33,7 @@ namespace AdventureWorks.UILogic.ViewModels
                 _lastSignedInUser = _accountService.SignedInUser;
             }
 
-            SignInCommand = new DelegateCommand(async () => SignInAsync, CanSignIn);
+            SignInCommand = new DelegateCommand(async () => await SignInAsync(), CanSignIn);
         }
 
         public string UserName

--- a/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/SignInUserControlViewModel.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.UILogic/ViewModels/SignInUserControlViewModel.cs
@@ -26,7 +26,7 @@ namespace AdventureWorks.UILogic.ViewModels
             _alertMessageService = alertMessageService;
             _resourceLoader = resourceLoader;
 
-            SignInCommand = new DelegateCommand(async () => SignInAsync, CanSignIn);
+            SignInCommand = new DelegateCommand(async () => await SignInAsync(), CanSignIn);
             GoBackCommand = new DelegateCommand(Close);
 
             if (_accountService.SignedInUser != null)


### PR DESCRIPTION
VS15.3 did not have problems with `new DelegateCommand(async () => SaveAsync);`

In 15.2 it doesn't build. So it becomes `new DelegateCommand(async () => await SaveAsync());`