### PR TITLE
ZipCode Validation failing

### DIFF
--- a/AdventureWorks.Shopper/AdventureWorks.WebServices/Models/Address.cs
+++ b/AdventureWorks.Shopper/AdventureWorks.WebServices/Models/Address.cs
@@ -88,7 +88,7 @@ namespace AdventureWorks.WebServices.Models
                 string stateName = address.State;
                 State state = new StateRepository().GetAll().FirstOrDefault(c => c.Name == stateName);
                 
-                if (Int32.TryParse(address.ZipCode.Substring(0, 3), out var zipCode))
+                if (!Int32.TryParse(address.ZipCode.Substring(0, 3), out var zipCode))
                 {
                     //Only supporting numeric zip codes.
                     return new ValidationResult(Resources.ErrorInvalidZipCodeInState);


### PR DESCRIPTION
Valid zip codes failing validation. 

Added a '!' to TryParse to fail validation on invalid numbers.

The ShippingAddressInfo.ZipCode.Text InputScope is 'number' type. When input 'aaa', the 1st level of validation fails before the 'TryParse' is called.

There is no TextLable/Resource text linked with the ZipCode if the content is not a number.


I'm new to Prism - How to set the ValidationResult text for ZipCode if it fails the 'InputScope' type ValidateProperties()?
